### PR TITLE
Add "+-" operator to "for" clauses

### DIFF
--- a/dsl/src/main/scala/ru/itclover/tsp/dsl/PatternsValidator.scala
+++ b/dsl/src/main/scala/ru/itclover/tsp/dsl/PatternsValidator.scala
@@ -1,9 +1,7 @@
-/*
 package ru.itclover.tsp.dsl
 
-import ru.itclover.tsp.core.Pattern
-import ru.itclover.tsp.dsl.schema.RawPattern
-import ru.itclover.tsp.io.TimeExtractor
+import ru.itclover.tsp.core.{Pattern, RawPattern}
+import ru.itclover.tsp.io.{Decoder, Extractor, TimeExtractor}
 
 object PatternsValidator {
 
@@ -11,9 +9,9 @@ object PatternsValidator {
     patterns: Seq[RawPattern]
   )(
     implicit timeExtractor: TimeExtractor[Event],
-    toNumberExtractor: Extractor[Event]
-  ): Seq[(RawPattern, Either[String, (Pattern[Event, _, _], PhaseMetadata)])] = {
+    toNumberExtractor: Extractor[Event, Int, Any],
+    doubleDecoder: Decoder[Any, Double]
+  ): Seq[(RawPattern, Either[String, (Pattern[Event, _, _], PatternMetadata)])] = {
     patterns.map(p => (p, PhaseBuilder.build(p.sourceCode, SyntaxParser.testFieldsIdxMap)))
   }
 }
-*/

--- a/http/src/main/scala/ru/itclover/tsp/http/HttpService.scala
+++ b/http/src/main/scala/ru/itclover/tsp/http/HttpService.scala
@@ -42,8 +42,8 @@ trait HttpService extends RoutesProtocols {
   def composeRoutes: Reader[ExecutionContextExecutor, Route] = for {
     jobs       <- JobsRoutes.fromExecutionContext(monitoringUri)
     monitoring <- MonitoringRoutes.fromExecutionContext(monitoringUri)
-    // validation <- ValidationRoutes.fromExecutionContext(monitoringUri)
-  } yield jobs ~ monitoring // ~ validation
+    validation <- ValidationRoutes.fromExecutionContext(monitoringUri)
+  } yield jobs ~ monitoring ~ validation
 
   def route = (logRequestAndResponse & handleErrors) {
     ignoreTrailingSlash {

--- a/http/src/main/scala/ru/itclover/tsp/http/routes/ValidationRoutes.scala
+++ b/http/src/main/scala/ru/itclover/tsp/http/routes/ValidationRoutes.scala
@@ -1,4 +1,3 @@
-/*
 package ru.itclover.tsp.http.routes
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling
@@ -9,12 +8,11 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
 import cats.data.Reader
-import ru.itclover.tsp.core.Time
-import ru.itclover.tsp.core.Time.TimeExtractor
-import ru.itclover.tsp.dsl.schema.RawPattern
+import ru.itclover.tsp.core.{RawPattern, Time}
 import ru.itclover.tsp.dsl.{PatternsValidator, PatternsValidatorConf}
 import ru.itclover.tsp.http.protocols.{PatternsValidatorProtocols, RoutesProtocols, ValidationResult}
-import ru.itclover.tsp.phases.NumericPhases.{IndexNumberExtractor, SymbolNumberExtractor}
+import ru.itclover.tsp.io.{TimeExtractor, Decoder, Extractor}
+
 import scala.concurrent.ExecutionContextExecutor
 
 object ValidationRoutes {
@@ -35,7 +33,12 @@ trait ValidationRoutes extends RoutesProtocols with PatternsValidatorProtocols {
       val patterns: Seq[RawPattern] = request.patterns
       val res = PatternsValidator.validate[Nothing](patterns)(
         new TimeExtractor[Nothing] { override def apply(v1: Nothing): Time = Time(0) },
-        new IndexNumberExtractor[Nothing] { override def extract(event: Nothing, index: Int): Double = 0.0 }
+        new Extractor[Nothing, Int, Any] {
+          override def apply[T](e: Nothing, k: Int)(implicit d: Decoder[Any, T]): T = 0.0
+        },
+        new Decoder[Any, Double] {
+          override def apply(v1: Any): Double = 0.0
+        }
       )
       val result = res.map { x =>
         x._2 match {
@@ -49,4 +52,3 @@ trait ValidationRoutes extends RoutesProtocols with PatternsValidatorProtocols {
     }
   }
 }
-*/


### PR DESCRIPTION
Examples 
- `a > 0 for 30 seconds +- 2 seconds` (28 to 32 seconds);
- `a > 0 for 30 seconds +- 20%` (24 to 36 seconds);
- `a > 0 for 30 seconds` (27 to 33 seconds, &plusmn; 10% margin by default)

The URL for patterns validation is now restored and works as expected.