### PR TITLE
Kafka sink support

### DIFF
--- a/flink/src/main/scala/ru/itclover/tsp/StreamSources.scala
+++ b/flink/src/main/scala/ru/itclover/tsp/StreamSources.scala
@@ -156,10 +156,11 @@ case class JdbcSource(conf: JDBCInputConf, fieldsClasses: Seq[(Symbol, Class[_])
       serializablePI.map(event.getField).mkString
   }
 
-  val tsMultiplier = timestampMultiplier.getOrElse {
+  def tsMultiplier = timestampMultiplier.getOrElse {
     log.info("timestampMultiplier in JDBC source conf is not provided, use default = 1000.0")
     1000.0
   }
+
   override def timeExtractor = RowTsTimeExtractor(timeIndex, tsMultiplier, datetimeField)
   override def extractor = RowSymbolExtractor(fieldsIdxMap)
   override def transformedExtractor = RowSymbolExtractor(transformedFieldsIdxMap)

--- a/http/src/main/scala/ru/itclover/tsp/http/protocols/RoutesProtocols.scala
+++ b/http/src/main/scala/ru/itclover/tsp/http/protocols/RoutesProtocols.scala
@@ -6,7 +6,7 @@ import ru.itclover.tsp.http.domain.input.{DSLPatternRequest, FindPatternsRequest
 import ru.itclover.tsp.http.domain.output.SuccessfulResponse.ExecInfo
 import ru.itclover.tsp.http.domain.output.{FailureResponse, SuccessfulResponse}
 import ru.itclover.tsp.io.input._
-import ru.itclover.tsp.io.output.{JDBCOutputConf, OutputConf, RowSchema}
+import ru.itclover.tsp.io.output.{JDBCOutputConf, KafkaOutputConf, OutputConf, RowSchema}
 import spray.json._
 
 trait RoutesProtocols extends SprayJsonSupport with DefaultJsonProtocol {
@@ -135,6 +135,8 @@ trait RoutesProtocols extends SprayJsonSupport with DefaultJsonProtocol {
   )
   // implicit val jdbcSinkSchemaFmt = jsonFormat(JDBCSegmentsSink.apply, "tableName", "rowSchema")
   implicit val jdbcOutConfFmt = jsonFormat8(JDBCOutputConf.apply)
+
+  implicit val kafkaOutConfFmt = jsonFormat4(KafkaOutputConf.apply)
 
   implicit val rawPatternFmt = jsonFormat4(RawPattern.apply)
 

--- a/integration/correctness/src/test/scala/ru/itclover/tsp/http/BasicJdbcToKafkaTest.scala
+++ b/integration/correctness/src/test/scala/ru/itclover/tsp/http/BasicJdbcToKafkaTest.scala
@@ -1,0 +1,116 @@
+package ru.itclover.tsp.http
+
+import java.util.concurrent.{SynchronousQueue, ThreadPoolExecutor, TimeUnit}
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import com.dimafeng.testcontainers._
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.scalatest.FlatSpec
+import ru.itclover.tsp.core.RawPattern
+import ru.itclover.tsp.http.domain.input.FindPatternsRequest
+import ru.itclover.tsp.http.utils.{JDBCContainer, SqlMatchers}
+import ru.itclover.tsp.io.input.JDBCInputConf
+import ru.itclover.tsp.io.output.{JDBCOutputConf, KafkaOutputConf, RowSchema}
+import ru.itclover.tsp.utils.Files
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+
+class BasicJdbcToKafkaTest extends FlatSpec with SqlMatchers with ScalatestRouteTest with HttpService with ForAllTestContainer {
+
+  implicit override val executionContext: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+  implicit override val streamEnvironment: StreamExecutionEnvironment =
+    StreamExecutionEnvironment.createLocalEnvironment()
+  streamEnvironment.setMaxParallelism(30000) // For proper keyBy partitioning
+
+  // to run blocking tasks.
+  val blockingExecutorContext: ExecutionContextExecutor =
+    ExecutionContext.fromExecutor(
+      new ThreadPoolExecutor(
+        0, // corePoolSize
+        Int.MaxValue, // maxPoolSize
+        1000L, //keepAliveTime
+        TimeUnit.MILLISECONDS, //timeUnit
+        new SynchronousQueue[Runnable](), //workQueue
+        new ThreadFactoryBuilder().setNameFormat("blocking-thread").setDaemon(true).build()
+      )
+    )
+
+  implicit def defaultTimeout(implicit system: ActorSystem) = RouteTestTimeout(300.seconds)
+
+  val port = 8170
+  val clickhouseContainer = new JDBCContainer(
+    "yandex/clickhouse-server:latest",
+    port -> 8123 :: 9080 -> 9000 :: Nil,
+    "ru.yandex.clickhouse.ClickHouseDriver",
+    s"jdbc:clickhouse://localhost:$port/default"
+  )
+
+  val inputConf = JDBCInputConf(
+    sourceId = 123,
+    jdbcUrl = clickhouseContainer.jdbcUrl,
+    query = """select *, speed as "speed(1)(2)" from Test.SM_basic_wide""", // speed(1)(2) fancy colnames test
+    driverName = clickhouseContainer.driverName,
+    datetimeField = 'datetime,
+    eventsMaxGapMs = 60000L,
+    defaultEventsGapMs = 1000L,
+    chunkSizeMs = Some(900000L),
+    partitionFields = Seq('series_id, 'mechanism_id)
+  )
+
+    val kafkaPort = 8092
+
+    val kafkaContainer = KafkaContainer()
+
+    implicit override val container = MultipleContainers(clickhouseContainer, kafkaContainer)
+
+  val typeCastingInputConf = inputConf.copy(query = "select * from Test.SM_typeCasting_wide limit 1000")
+
+  val rowSchema = RowSchema('series_storage, 'from, 'to, ('app, 1), 'id, 'timestamp, 'context, inputConf.partitionFields)
+
+  val outputConf = KafkaOutputConf(
+    "127.0.0.1:9092",
+    "SM_basic_patterns",
+    rowSchema
+  )
+
+  val basicAssertions = Seq(
+    RawPattern("1", "speed < 15"),
+    RawPattern("2", """"speed(1)(2)" > 10"""),
+    RawPattern("3", "speed > 10.0", Map("test" -> "test"), Seq('speed))
+  )
+  val typesCasting = Seq(RawPattern("10", "speed = 15"), RawPattern("11", "speed64 < 15.0"))
+  val errors = Seq(RawPattern("20", "speed = QWE 15"), RawPattern("21", "speed64 < 15.0"))
+
+  override def afterStart(): Unit = {
+    super.afterStart()
+    Files.readResource("/sql/test-db-schema.sql").mkString.split(";").map(clickhouseContainer.executeUpdate)
+    Files.readResource("/sql/wide/source-schema.sql").mkString.split(";").map(clickhouseContainer.executeUpdate)
+    Files.readResource("/sql/wide/source-inserts.sql").mkString.split(";").map(clickhouseContainer.executeUpdate)
+    Files.readResource("/sql/sink-schema.sql").mkString.split(";").map(clickhouseContainer.executeUpdate)
+  }
+
+  "Basic assertions and forwarded fields" should "work for wide dense table" in {
+
+    Post("/streamJob/from-jdbc/to-kafka/?run_async=0", FindPatternsRequest("1", inputConf, outputConf, basicAssertions)) ~>
+    route ~> check {
+      entityAs[String] shouldBe ""
+      status shouldEqual StatusCodes.OK
+    }
+  }
+
+  "Types casting" should "work for wide dense table" in {
+    Post(
+      "/streamJob/from-jdbc/to-kafka/?run_async=0",
+      FindPatternsRequest("1", typeCastingInputConf, outputConf, typesCasting)
+    ) ~>
+    route ~> check {
+      entityAs[String] shouldBe ""
+      status shouldEqual StatusCodes.OK
+
+    }
+  }
+}

--- a/integration/correctness/src/test/scala/ru/itclover/tsp/http/KafkaTest.scala
+++ b/integration/correctness/src/test/scala/ru/itclover/tsp/http/KafkaTest.scala
@@ -1,113 +1,113 @@
-package ru.itclover.tsp.http
-
-import java.util.concurrent.{SynchronousQueue, ThreadPoolExecutor, TimeUnit}
-
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import com.dimafeng.testcontainers._
-import com.google.common.util.concurrent.ThreadFactoryBuilder
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.scalatest.FlatSpec
-import ru.itclover.tsp.core.RawPattern
-import ru.itclover.tsp.http.domain.input.FindPatternsRequest
-import ru.itclover.tsp.http.utils.{JDBCContainer, SqlMatchers}
-import ru.itclover.tsp.io.input.KafkaInputConf
-import ru.itclover.tsp.io.output.{JDBCOutputConf, RowSchema}
-
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
-import scala.concurrent.duration.DurationInt
-
-class KafkaTest extends FlatSpec with SqlMatchers with ScalatestRouteTest with HttpService with ForAllTestContainer {
-
-  implicit override val executionContext: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
-  implicit override val streamEnvironment: StreamExecutionEnvironment =
-    StreamExecutionEnvironment.createLocalEnvironment()
-  streamEnvironment.setMaxParallelism(30000) // For proper keyBy partitioning
-
-  // to run blocking tasks.
-  val blockingExecutorContext: ExecutionContextExecutor =
-    ExecutionContext.fromExecutor(
-      new ThreadPoolExecutor(
-        0, // corePoolSize
-        Int.MaxValue, // maxPoolSize
-        1000L, //keepAliveTime
-        TimeUnit.MILLISECONDS, //timeUnit
-        new SynchronousQueue[Runnable](), //workQueue
-        new ThreadFactoryBuilder().setNameFormat("blocking-thread").setDaemon(true).build()
-      )
-    )
-
-  implicit def defaultTimeout(implicit system: ActorSystem) = RouteTestTimeout(300.seconds)
-
-  val port = 8166
-  val clickhouseContainer = new JDBCContainer(
-    "yandex/clickhouse-server:latest",
-    port -> 8123 :: 9089 -> 9000 :: Nil,
-    "ru.yandex.clickhouse.ClickHouseDriver",
-    s"jdbc:clickhouse://localhost:$port/default"
-  )
-
-  val kafkaPort = 8092
-
-  val kafkaContainer = KafkaContainer()
-
-  implicit override val container = MultipleContainers(clickhouseContainer, kafkaContainer)
-
-  val inputConf = KafkaInputConf(
-    brokers = "127.0.0.1:9092",
-    topic = "batch_record_small_stream_writer",
-    group = "group5",
-    datetimeField = 'and,
-    partitionFields = Seq('series_id, 'mechanism_id),
-    dataTransformation = None,
-    timestampMultiplier = Option(1000.0)
-  )
-
-  // val typeCastingInputConf = inputConf.copy(query = "select * from Test.SM_typeCasting_wide limit 1000")
-
-  val rowSchema = RowSchema('series_storage, 'from, 'to, ('app, 1), 'id, 'timestamp, 'context, inputConf.partitionFields)
-
-  val outputConf = JDBCOutputConf(
-    "Test.SM_basic_wide_patterns",
-    rowSchema,
-    s"jdbc:clickhouse://localhost:$port/default",
-    "ru.yandex.clickhouse.ClickHouseDriver"
-  )
-
-  val basicAssertions = Seq(
-    RawPattern("1", "speed < 15"),
-    RawPattern("2", """"speed(1)(2)" > 10"""),
-    RawPattern("3", "speed > 10.0", Map("test" -> "test"), Seq('speed))
-  )
-  // val typesCasting = Seq(RawPattern("10", "speed = 15"), RawPattern("11", "speed64 < 15.0"))
-  // val errors = Seq(RawPattern("20", "speed = QWE 15"), RawPattern("21", "speed64 < 15.0"))
-
-  // override def afterStart(): Unit = {
-  //   super.afterStart()
-  //   Files.readResource("/sql/test-db-schema.sql").mkString.split(";").map(container.executeUpdate)
-  //   Files.readResource("/sql/wide/source-schema.sql").mkString.split(";").map(container.executeUpdate)
-  //   Files.readResource("/sql/wide/source-inserts.sql").mkString.split(";").map(container.executeUpdate)
-  //   Files.readResource("/sql/wide/sink-schema.sql").mkString.split(";").map(container.executeUpdate)
-  // }
-
-  "Basic assertions and forwarded fields" should "work for wide dense table" in {
-
-    Post("/streamJob/from-kafka/to-jdbc/?run_async=0", FindPatternsRequest("1", inputConf, outputConf, basicAssertions)) ~>
-    route ~> check {
-      status shouldEqual StatusCodes.OK
-
-    }
-  }
-
-  // "Types casting" should "work for wide dense table" in {
-  //   Post(
-  //     "/streamJob/from-jdbc/to-jdbc/?run_async=0",
-  //     FindPatternsRequest("1", typeCastingInputConf, outputConf, typesCasting)
-  //   ) ~>
-  //   route ~> check {
-  //     status shouldEqual StatusCodes.OK
-
-  //   }
-  // }
-}
+//package ru.itclover.tsp.http
+//
+//import java.util.concurrent.{SynchronousQueue, ThreadPoolExecutor, TimeUnit}
+//
+//import akka.actor.ActorSystem
+//import akka.http.scaladsl.model.StatusCodes
+//import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+//import com.dimafeng.testcontainers._
+//import com.google.common.util.concurrent.ThreadFactoryBuilder
+//import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+//import org.scalatest.FlatSpec
+//import ru.itclover.tsp.core.RawPattern
+//import ru.itclover.tsp.http.domain.input.FindPatternsRequest
+//import ru.itclover.tsp.http.utils.{JDBCContainer, SqlMatchers}
+//import ru.itclover.tsp.io.input.KafkaInputConf
+//import ru.itclover.tsp.io.output.{JDBCOutputConf, RowSchema}
+//
+//import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+//import scala.concurrent.duration.DurationInt
+//
+//class KafkaTest extends FlatSpec with SqlMatchers with ScalatestRouteTest with HttpService with ForAllTestContainer {
+//
+//  implicit override val executionContext: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+//  implicit override val streamEnvironment: StreamExecutionEnvironment =
+//    StreamExecutionEnvironment.createLocalEnvironment()
+//  streamEnvironment.setMaxParallelism(30000) // For proper keyBy partitioning
+//
+//  // to run blocking tasks.
+//  val blockingExecutorContext: ExecutionContextExecutor =
+//    ExecutionContext.fromExecutor(
+//      new ThreadPoolExecutor(
+//        0, // corePoolSize
+//        Int.MaxValue, // maxPoolSize
+//        1000L, //keepAliveTime
+//        TimeUnit.MILLISECONDS, //timeUnit
+//        new SynchronousQueue[Runnable](), //workQueue
+//        new ThreadFactoryBuilder().setNameFormat("blocking-thread").setDaemon(true).build()
+//      )
+//    )
+//
+//  implicit def defaultTimeout(implicit system: ActorSystem) = RouteTestTimeout(300.seconds)
+//
+//  val port = 8166
+//  val clickhouseContainer = new JDBCContainer(
+//    "yandex/clickhouse-server:latest",
+//    port -> 8123 :: 9089 -> 9000 :: Nil,
+//    "ru.yandex.clickhouse.ClickHouseDriver",
+//    s"jdbc:clickhouse://localhost:$port/default"
+//  )
+//
+//  val kafkaPort = 8092
+//
+//  val kafkaContainer = KafkaContainer()
+//
+//  implicit override val container = MultipleContainers(clickhouseContainer, kafkaContainer)
+//
+//  val inputConf = KafkaInputConf(
+//    brokers = "127.0.0.1:9092",
+//    topic = "batch_record_small_stream_writer",
+//    group = "group5",
+//    datetimeField = 'and,
+//    partitionFields = Seq('series_id, 'mechanism_id),
+//    dataTransformation = None,
+//    timestampMultiplier = Option(1000.0)
+//  )
+//
+//  // val typeCastingInputConf = inputConf.copy(query = "select * from Test.SM_typeCasting_wide limit 1000")
+//
+//  val rowSchema = RowSchema('series_storage, 'from, 'to, ('app, 1), 'id, 'timestamp, 'context, inputConf.partitionFields)
+//
+//  val outputConf = JDBCOutputConf(
+//    "Test.SM_basic_wide_patterns",
+//    rowSchema,
+//    s"jdbc:clickhouse://localhost:$port/default",
+//    "ru.yandex.clickhouse.ClickHouseDriver"
+//  )
+//
+//  val basicAssertions = Seq(
+//    RawPattern("1", "speed < 15"),
+//    RawPattern("2", """"speed(1)(2)" > 10"""),
+//    RawPattern("3", "speed > 10.0", Map("test" -> "test"), Seq('speed))
+//  )
+//  // val typesCasting = Seq(RawPattern("10", "speed = 15"), RawPattern("11", "speed64 < 15.0"))
+//  // val errors = Seq(RawPattern("20", "speed = QWE 15"), RawPattern("21", "speed64 < 15.0"))
+//
+//  // override def afterStart(): Unit = {
+//  //   super.afterStart()
+//  //   Files.readResource("/sql/test-db-schema.sql").mkString.split(";").map(container.executeUpdate)
+//  //   Files.readResource("/sql/wide/source-schema.sql").mkString.split(";").map(container.executeUpdate)
+//  //   Files.readResource("/sql/wide/source-inserts.sql").mkString.split(";").map(container.executeUpdate)
+//  //   Files.readResource("/sql/wide/sink-schema.sql").mkString.split(";").map(container.executeUpdate)
+//  // }
+//
+//  "Basic assertions and forwarded fields" should "work for wide dense table" in {
+//
+//    Post("/streamJob/from-kafka/to-jdbc/?run_async=0", FindPatternsRequest("1", inputConf, outputConf, basicAssertions)) ~>
+//    route ~> check {
+//      status shouldEqual StatusCodes.OK
+//
+//    }
+//  }
+//
+//  // "Types casting" should "work for wide dense table" in {
+//  //   Post(
+//  //     "/streamJob/from-jdbc/to-jdbc/?run_async=0",
+//  //     FindPatternsRequest("1", typeCastingInputConf, outputConf, typesCasting)
+//  //   ) ~>
+//  //   route ~> check {
+//  //     status shouldEqual StatusCodes.OK
+//
+//  //   }
+//  // }
+//}

--- a/integration/performance/src/test/scala/ru/itclover/tsp/http/utils/JDBCContainer.scala
+++ b/integration/performance/src/test/scala/ru/itclover/tsp/http/utils/JDBCContainer.scala
@@ -3,7 +3,6 @@ package ru.itclover.tsp.http.utils
 import java.sql.{Connection, DriverManager, ResultSet}
 
 import com.dimafeng.testcontainers.SingleContainer
-import org.junit.runner.Description
 import org.testcontainers.containers.wait.strategy.WaitStrategy
 import org.testcontainers.containers.{BindMode, GenericContainer => OTCGenericContainer}
 
@@ -37,16 +36,16 @@ class JDBCContainer(imageName: String,
 
   var connection: Connection = _
 
-  override def starting()(implicit description: Description): Unit = {
-    super.starting()
+  override def start(): Unit = {
+    super.start()
     connection = {
       Class.forName(driverName)
       DriverManager.getConnection(jdbcUrl)
     }
   }
 
-  override def finished()(implicit description: Description): Unit = {
-    super.finished()
+  override def stop(): Unit = {
+    super.stop()
     connection.close()
   }
 

--- a/project/Library.scala
+++ b/project/Library.scala
@@ -77,7 +77,8 @@ object Library {
     "org.apache.flink" %% "flink-streaming-scala" % Version.flink,
     "org.apache.flink" % "flink-connector-kafka_2.12" % Version.flink,
     "org.apache.flink" % "flink-jdbc_2.12" % Version.flink,
-    "org.apache.flink" % "flink-metrics-dropwizard" % Version.flink
+    "org.apache.flink" % "flink-metrics-dropwizard" % Version.flink,
+    "org.apache.flink" % "flink-avro" % Version.flink
   )
 
   val akka = Seq(


### PR DESCRIPTION
Kafka sink support. Example in request (`sink` key):
```
"sink": {
		"broker": "127.0.0.1:9092",
		"topic": "out_topic",
		"rowSchema": {
			"toTsField": "to_ts",
			"fromTsField": "from_ts",
			"contextField": "context",
			"appIdFieldVal": [
				"type",
				1
			],
			"sourceIdField": "series_storage",
			"patternIdField": "entity_id",
			"forwardedFields": [
				"loco_num",
				"Section",
				"upload_id"
			],
			"processingTsField": "processing_ts"
		}
	}
```