### PR TITLE
Narrow table fixes

### DIFF
--- a/dsl/src/main/scala/ru/itclover/tsp/dsl/PatternFieldExtractor.scala
+++ b/dsl/src/main/scala/ru/itclover/tsp/dsl/PatternFieldExtractor.scala
@@ -1,0 +1,28 @@
+package ru.itclover.tsp.dsl
+
+import ru.itclover.tsp.core.Pattern.TsIdxExtractor
+import ru.itclover.tsp.core.{RawPattern, Time}
+import ru.itclover.tsp.core.io.{Decoder, Extractor, TimeExtractor}
+
+
+// Helper method to extract only the used fields (identifiers) from the list of patterns
+object PatternFieldExtractor {
+  def extract[E, EKey, EItem](patterns: Seq[RawPattern])(
+    implicit fieldToEKey: Symbol => EKey,
+  ): Set[EKey] = {
+    val dummyTimeExtractor = new TimeExtractor[E] {
+      override def apply(e: E): Time = Time(0)
+    }
+    val dummyExtractor = new Extractor[E, EKey, EItem] {
+      override def apply[T](e: E, k: EKey)(implicit d: Decoder[EItem, T]): T = null.asInstanceOf[T]
+    }
+
+    val tsToIdx = new TsIdxExtractor[E](dummyTimeExtractor(_).toMillis)
+    val gen = ASTPatternGenerator[E, EKey, EItem]()(tsToIdx, dummyTimeExtractor, dummyExtractor, fieldToEKey, tsToIdx)
+    patterns.map { p =>
+      gen.build(p.sourceCode, 0.0, Map.empty)
+        .map(_._2.fields.map(fieldToEKey))
+        .getOrElse(Set.empty)
+    }.foldLeft(Set.empty[EKey])(_ ++ _)
+  }
+}

--- a/flink/src/main/scala/ru/itclover/tsp/PatternsSearchJob.scala
+++ b/flink/src/main/scala/ru/itclover/tsp/PatternsSearchJob.scala
@@ -113,7 +113,7 @@ case class PatternsSearchJob[In: TypeInformation, InKey, InItem](
     }
     val keyedStream = stream
       .assignAscendingTimestamps(timeExtractor(_).toMillis)
-      .keyBy(source.partitioner)
+      .keyBy(source.transformedPartitioner)
     val windowed =  if (useWindowing) {
       keyedStream
         .window(

--- a/flink/src/main/scala/ru/itclover/tsp/PatternsSearchJob.scala
+++ b/flink/src/main/scala/ru/itclover/tsp/PatternsSearchJob.scala
@@ -35,6 +35,7 @@ import scala.reflect.ClassTag
 
 case class PatternsSearchJob[In: TypeInformation, InKey, InItem](
   source: StreamSource[In, InKey, InItem],
+  fields: Set[InKey],
   decoders: BasicDecoders[InItem]
 ) {
   // TODO: Restore InKey as a type parameter
@@ -138,7 +139,7 @@ case class PatternsSearchJob[In: TypeInformation, InKey, InItem](
     case Some(_) =>
       import source.{extractor, timeExtractor}
       dataStream
-        .flatMap(SparseRowsDataAccumulator[In, InKey, InItem, In](source.asInstanceOf[StreamSource[In, InKey, InItem]]))
+        .flatMap(SparseRowsDataAccumulator[In, InKey, InItem, In](source.asInstanceOf[StreamSource[In, InKey, InItem]], fields))
         .setParallelism(1) // SparseRowsDataAccumulator cannot work in parallel
     case _ => dataStream
   }

--- a/flink/src/main/scala/ru/itclover/tsp/PatternsSearchJob.scala
+++ b/flink/src/main/scala/ru/itclover/tsp/PatternsSearchJob.scala
@@ -139,7 +139,8 @@ case class PatternsSearchJob[In: TypeInformation, InKey, InItem](
     case Some(_) =>
       import source.{extractor, timeExtractor}
       dataStream
-        .flatMap(SparseRowsDataAccumulator[In, InKey, InItem, In](source.asInstanceOf[StreamSource[In, InKey, InItem]], fields))
+        .keyBy(source.partitioner)
+        .process(SparseRowsDataAccumulator[In, InKey, InItem, In](source.asInstanceOf[StreamSource[In, InKey, InItem]], fields))
         .setParallelism(1) // SparseRowsDataAccumulator cannot work in parallel
     case _ => dataStream
   }

--- a/flink/src/main/scala/ru/itclover/tsp/transformers/SparseDataAccumulator.scala
+++ b/flink/src/main/scala/ru/itclover/tsp/transformers/SparseDataAccumulator.scala
@@ -94,12 +94,12 @@ case class SparseRowsDataAccumulator[InEvent, InKey, Value, OutEvent](
         case (k, (v, _)) if indexesMap.contains(k) => list(indexesMap(k)) = (k, v.asInstanceOf[AnyRef])
         case _                                     =>
       }
-      if (defaultTimeout.isEmpty) {
+      //if (defaultTimeout.isEmpty) {
         extraFieldNames.foreach { name =>
           val value = extractValue(item, name)
           if (value != null) list(extraFieldsIndexesMap(name)) = (name, value.asInstanceOf[AnyRef])
         }
-      }
+      //}
       val outEvent = eventCreator.create(list)
       if (lastTimestamp.toMillis != time.toMillis && lastEvent != null) {
         out.collect(lastEvent)


### PR DESCRIPTION
- default timeout now works
- fixed multiple wide (unfolded) rows emitting on several narrow rows with the same timestamp
- added partitioning upon unfolding