### PR TITLE
Simple cases now check timestamps

### DIFF
--- a/core/src/main/scala/ru/itclover/tsp/core/AndThenPattern.scala
+++ b/core/src/main/scala/ru/itclover/tsp/core/AndThenPattern.scala
@@ -58,8 +58,10 @@ case class AndThenPattern[Event, T1, T2, S1, S2](first: Pattern[Event, S1, T1], 
               total.enqueue(IdxValue(start1, end1, Result.fail))
             )
           } else if (value2.isFail) {
-            // Do not return Fail for the first part yet
-            inner(first/*.rewindTo(end2)*/, second.behead(), total/*.enqueue(IdxValue(start1, end2, Fail))*/)
+            // Do not return Fail for the first part yet, unless it is the end of the queue
+            first.size match {
+              case 1 => inner(first.rewindTo(end2 + 1), second.behead(), total.enqueue(IdxValue(start1, end2, Fail)))
+              case _ => inner(first, second.behead(), total)}
           } else { // at this moment both first and second results are not Fail.
             // late event from second, just skip it and fail this part only.
             // first            |-------|

--- a/core/src/main/scala/ru/itclover/tsp/core/AndThenPattern.scala
+++ b/core/src/main/scala/ru/itclover/tsp/core/AndThenPattern.scala
@@ -58,19 +58,20 @@ case class AndThenPattern[Event, T1, T2, S1, S2](first: Pattern[Event, S1, T1], 
               total.enqueue(IdxValue(start1, end1, Result.fail))
             )
           } else if (value2.isFail) {
-            inner(first.rewindTo(end2), second.behead(), total.enqueue(IdxValue(start1, end2, Fail)))
+            // Do not return Fail for the first part yet
+            inner(first/*.rewindTo(end2)*/, second.behead(), total/*.enqueue(IdxValue(start1, end2, Fail))*/)
           } else { // at this moment both first and second results are not Fail.
-            // late event from second, just skip it
+            // late event from second, just skip it and fail this part only.
             // first            |-------|
             // second  |------|
             if (start1 > end2) {
-              inner(first, second.behead(), total)
+              inner(first, second.behead(), total.enqueue(IdxValue(start2, end2, Fail)))
             }
-            // Gap between first and second. Just behead first
+            // Gap between first and second. Just behead first and fail this part only.
             // first   |-------|
             // second             |------|
             else if (end1 + 1 < start2) {
-              inner(first.behead(), second, total)
+              inner(first.behead(), second, total.enqueue(IdxValue(start1, end1, Fail)))
             }
             // First and second intersect
             // first   |-------|

--- a/integration/correctness/src/test/scala/ru/itclover/tsp/http/utils/SqlMatchers.scala
+++ b/integration/correctness/src/test/scala/ru/itclover/tsp/http/utils/SqlMatchers.scala
@@ -36,10 +36,12 @@ trait SqlMatchers extends Matchers {
         case (x, y) => customEqualityList.areEqual(x, y)
       }
     }
-    val unfound = expectedValues.filter(!results.contains(_))
-    val unexpected = results.filter(!expectedValues.contains(_))
+    val unfound = expectedValues.filter(x => !results.exists(y => customEqualityList.areEqual(x.toList, y)))
+    val unexpected = results.filter(x => !expectedValues.exists(y => customEqualityList.areEqual(x.toList, y)))
     withClue(s"Expected but not found: [${toStringRepresentation(unfound)}]; found [${toStringRepresentation(unexpected)}] instead") {
-      results should ===(expectedValues)
+      // results should ===(expectedValues)
+      unfound shouldBe empty
+      unexpected shouldBe empty
     }
   }
 
@@ -64,10 +66,12 @@ trait SqlMatchers extends Matchers {
         case (x, y) => customEqualityList.areEqual(x, y)
       }
     }
-    val unfound = expectedValues.filter(!results.contains(_))
-    val unexpected = results.filter(!expectedValues.contains(_))
+    val unfound = expectedValues.filter(x => !results.exists(y => customEqualityList.areEqual(x.toList, y)))
+    val unexpected = results.filter(x => !expectedValues.exists(y => customEqualityList.areEqual(x.toList, y)))
     withClue(s"Expected but not found: [${toStringRepresentation(unfound)}]; found [${toStringRepresentation(unexpected)}] instead") {
-      results should ===(expectedValues)
+      // results should ===(expectedValues)
+      unfound shouldBe empty
+      unexpected shouldBe empty
     }
   }
 


### PR DESCRIPTION
Not only the count of incidents, but also their timestamps.
Additionally, `AndThenPattern` behaviour has slightly changed, now it returns union of both parts, not only their intersection (it seems more logical).