### PR TITLE
Multinarrow table support

### DIFF
--- a/flink/src/main/scala/ru/itclover/tsp/PatternsSearchJob.scala
+++ b/flink/src/main/scala/ru/itclover/tsp/PatternsSearchJob.scala
@@ -50,7 +50,7 @@ case class PatternsSearchJob[In: TypeInformation, InKey, InItem](
       source.fieldToEKey,
       source.conf.defaultToleranceFraction.getOrElse(0),
       source.conf.eventsMaxGapMs,
-      source.fieldsClasses.map { case (s, c) => s -> ClassTag(c) }.toMap,
+      source.transformedFieldsClasses.map { case (s, c) => s -> ClassTag(c) }.toMap,
       source.patternFields
     ).map { patterns =>
       val forwardFields = outputConf.forwardedFieldsIds.map(id => (id, source.fieldToEKey(id)))

--- a/flink/src/main/scala/ru/itclover/tsp/StreamSources.scala
+++ b/flink/src/main/scala/ru/itclover/tsp/StreamSources.scala
@@ -33,7 +33,29 @@ trait StreamSource[Event, EKey, EItem] extends Product with Serializable {
 
   def fieldsClasses: Seq[(Symbol, Class[_])]
 
+  def transformedFieldsClasses: Seq[(Symbol, Class[_])] = conf.dataTransformation match {
+    case Some(NarrowDataUnfolding(key, value, _, mapping, _)) =>
+      val m: Map[EKey, List[EKey]] = mapping.getOrElse(Map.empty)
+      val r = fieldsClasses ++ m.map {
+        case (col, list) => list.map(k => (eKeyToField(k), fieldsClasses.find {
+          case (s, _) => fieldToEKey(s) == col
+        }.map(_._2).getOrElse(defaultClass)))
+      }.flatten
+      r
+    case _ =>
+      fieldsClasses
+  }
+
+  def defaultClass: Class[_] = conf.dataTransformation match {
+    case Some(NarrowDataUnfolding(_, value, _, _, _)) =>
+      fieldsClasses.find { case (s, _) => fieldToEKey(s) == value }.map(_._2).getOrElse(classOf[Double])
+    case _ =>
+      classOf[Double]
+  }
+
   def fieldToEKey: Symbol => EKey
+
+  def eKeyToField: EKey => Symbol
 
   def fieldsIdxMap: Map[Symbol, Int]
 
@@ -61,10 +83,13 @@ trait StreamSource[Event, EKey, EItem] extends Product with Serializable {
     case Some(NarrowDataUnfolding(key, value, _, mapping, _)) =>
       (r: Event) =>
         // TODO: Maybe optimise that by using intermediate (non-serialised) dictionary
+        val extractedKey = extractor.apply[EKey](r, key)
         val valueColumn = mapping.getOrElse(Map.empty[EKey, List[EKey]]).toSeq.find {
-          case (_, list) => list.contains(key)
+          case (_, list) =>
+            list.contains(extractedKey)
         }.map(_._1).getOrElse(value)
-        (extractor.apply[EKey](r, key), extractor.apply[EItem](r, valueColumn)) // TODO: See that place better
+        val extractedValue = extractor.apply[EItem](r, valueColumn)
+        (extractedKey, extractedValue) // TODO: See that place better
     case Some(WideDataFilling(_, _)) =>
       (_: Event) => sys.error("Wide data filling does not need K-V extractor")
     case Some(_) =>
@@ -168,6 +193,10 @@ case class JdbcSource(
   override def fieldToEKey = { fieldId: Symbol =>
     fieldId
   // fieldsIdxMap(fieldId)
+  }
+
+  override def eKeyToField: Symbol => Symbol = { key: Symbol =>
+    key
   }
 
   override def partitioner: RowWithIdx => String = {
@@ -317,6 +346,8 @@ case class InfluxDBSource(
 
   override def fieldToEKey = (fieldId: Symbol) => fieldId // fieldsIdxMap(fieldId)
 
+  override def eKeyToField: Symbol => Symbol = (key: Symbol) => key
+
   override def partitioner = {
     val serializablePI = partitionsIdx
     event: RowWithIdx => serializablePI.map(event.row.getField).mkString
@@ -408,6 +439,9 @@ case class KafkaSource(
   def fieldsIdxMap = fieldsIdx.toMap
 
   override def fieldToEKey: Symbol => Symbol = (x => x)
+
+  override def eKeyToField: Symbol => Symbol = (key: Symbol) => key
+
 
   def timeIndex = fieldsIdxMap(conf.datetimeField)
 
@@ -545,6 +579,9 @@ case class RedisSource(
   }
 
   override def fieldToEKey: Symbol => Symbol = (x => x)
+
+  override def eKeyToField: Symbol => Symbol = (key: Symbol) => key
+
 
   override def transformedFieldsIdxMap: Map[Symbol, Int] = conf.dataTransformation match {
     case Some(_) =>

--- a/flink/src/main/scala/ru/itclover/tsp/io/input/SourceDataTransformationConf.scala
+++ b/flink/src/main/scala/ru/itclover/tsp/io/input/SourceDataTransformationConf.scala
@@ -8,8 +8,9 @@ abstract class SourceDataTransformation[Event, EKey, EValue](val `type`: String)
 
 case class NarrowDataUnfolding[Event, EKey, EValue](
   keyColumn: EKey,
-  valueColumn: EKey,
+  defaultValueColumn: EKey,
   fieldsTimeoutsMs: Map[EKey, Long],
+  valueColumnMapping: Option[Map[EKey, List[EKey]]] = None,
   defaultTimeout: Option[Long] = None
 ) extends SourceDataTransformation[Event, EKey, EValue]("NarrowDataUnfolding")
     with SourceDataTransformationConf {

--- a/flink/src/main/scala/ru/itclover/tsp/transformers/SparseDataAccumulator.scala
+++ b/flink/src/main/scala/ru/itclover/tsp/transformers/SparseDataAccumulator.scala
@@ -150,7 +150,7 @@ object SparseRowsDataAccumulator {
             ndu.fieldsTimeoutsMs
           val extraFields = fim
             .filterNot {
-              case (name, _) => name == sparseRowsConf.keyColumn || name == sparseRowsConf.valueColumn
+              case (name, _) => name == sparseRowsConf.keyColumn || name == sparseRowsConf.defaultValueColumn
             }
             .keys
             .toSeq

--- a/http/src/main/scala/ru/itclover/tsp/http/protocols/RoutesProtocols.scala
+++ b/http/src/main/scala/ru/itclover/tsp/http/protocols/RoutesProtocols.scala
@@ -47,7 +47,7 @@ trait RoutesProtocols extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val fResponseFmt = jsonFormat3(FailureResponse.apply)
   implicit def nduFormat[Event, EKey: JsonFormat, EValue: JsonFormat] =
-    jsonFormat(NarrowDataUnfolding[Event, EKey, EValue], "key", "value", "fieldsTimeoutsMs", "defaultTimeout")
+    jsonFormat(NarrowDataUnfolding[Event, EKey, EValue], "key", "defaultValueColumn", "fieldsTimeoutsMs", "defaultTimeout", "valueColumnMapping")
   implicit def wdfFormat[Event, EKey: JsonFormat, EValue: JsonFormat] =
     jsonFormat(WideDataFilling[Event, EKey, EValue], "fieldsTimeoutsMs", "defaultTimeout")
 

--- a/http/src/main/scala/ru/itclover/tsp/http/protocols/RoutesProtocols.scala
+++ b/http/src/main/scala/ru/itclover/tsp/http/protocols/RoutesProtocols.scala
@@ -47,7 +47,7 @@ trait RoutesProtocols extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val fResponseFmt = jsonFormat3(FailureResponse.apply)
   implicit def nduFormat[Event, EKey: JsonFormat, EValue: JsonFormat] =
-    jsonFormat(NarrowDataUnfolding[Event, EKey, EValue], "key", "defaultValueColumn", "fieldsTimeoutsMs", "defaultTimeout", "valueColumnMapping")
+    jsonFormat(NarrowDataUnfolding[Event, EKey, EValue], "key", "defaultValueColumn", "fieldsTimeoutsMs", "valueColumnMapping","defaultTimeout")
   implicit def wdfFormat[Event, EKey: JsonFormat, EValue: JsonFormat] =
     jsonFormat(WideDataFilling[Event, EKey, EValue], "fieldsTimeoutsMs", "defaultTimeout")
 

--- a/http/src/main/scala/ru/itclover/tsp/http/protocols/RoutesProtocols.scala
+++ b/http/src/main/scala/ru/itclover/tsp/http/protocols/RoutesProtocols.scala
@@ -47,7 +47,7 @@ trait RoutesProtocols extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val fResponseFmt = jsonFormat3(FailureResponse.apply)
   implicit def nduFormat[Event, EKey: JsonFormat, EValue: JsonFormat] =
-    jsonFormat(NarrowDataUnfolding[Event, EKey, EValue], "key", "defaultValueColumn", "fieldsTimeoutsMs", "valueColumnMapping","defaultTimeout")
+    jsonFormat(NarrowDataUnfolding[Event, EKey, EValue], "keyColumn", "defaultValueColumn", "fieldsTimeoutsMs", "valueColumnMapping","defaultTimeout")
   implicit def wdfFormat[Event, EKey: JsonFormat, EValue: JsonFormat] =
     jsonFormat(WideDataFilling[Event, EKey, EValue], "fieldsTimeoutsMs", "defaultTimeout")
 

--- a/integration/correctness/src/test/scala/ru/itclover/tsp/http/SimpleCasesTest.scala
+++ b/integration/correctness/src/test/scala/ru/itclover/tsp/http/SimpleCasesTest.scala
@@ -268,7 +268,7 @@ class SimpleCasesTest
     defaultEventsGapMs = 1000L,
     chunkSizeMs = Some(900000L),
     partitionFields = Seq('loco_num, 'section, 'upload_id),
-    dataTransformation = Some(NarrowDataUnfolding('sensor_id, 'value_float, Map(), Some(1000))),
+    dataTransformation = Some(NarrowDataUnfolding('sensor_id, 'value_float, Map.empty, Some(Map.empty), Some(1000))),
   )
 
   val influxInputConf = InfluxDBInputConf(
@@ -295,7 +295,7 @@ class SimpleCasesTest
     defaultEventsGapMs = 1000L,
     chunkSizeMs = Some(900000L),
     partitionFields = Seq('stock_num,'upload_id),
-    dataTransformation = Some(NarrowDataUnfolding('sensor_id, 'value_float, Map.empty, Some(15000L))),
+    dataTransformation = Some(NarrowDataUnfolding('sensor_id, 'value_float, Map.empty, Some(Map.empty), Some(15000L))),
   )
 
   val wideInputIvolgaConf = JDBCInputConf(


### PR DESCRIPTION
Support for reading narrow-table values from multiple column (different one for floats and strings, for example).

JSON example (`source/dataTransformation`):
```json
"config": {
  "key": "sensor_id",
  "defaultValueColumn": "value_float", 
  "defaultTimeout": 60000,
  "fieldsTimeoutsMs": {},
  "valueColumnMapping": {
     "value_string": ["SOC_3_CURRENT", "ABKM_brake_ctrl_Brake_Pos_A"]
 }
```